### PR TITLE
Extra hardware: specify pull package, install IB diags

### DIFF
--- a/elements/ipa-extra-hardware/README.rst
+++ b/elements/ipa-extra-hardware/README.rst
@@ -14,7 +14,10 @@ or the ``ipa-inspection-collectors`` kernel command line argument.
 
 The following environment variables may be set to configure the element:
 
+* ``DIB_IPA_HARDWARE_PACKAGE`` the full ``hardware`` Python package descriptor
+  to use. If unset, ``DIB_IPA_HARDWARE_VERSION`` will be used.
 * ``DIB_IPA_HARDWARE_VERSION`` the version of the ``hardware`` package to
-  install. If unset, the latest version will be installed.
+  install when ``DIB_IPA_HARDWARE_PACKAGE`` is unset. If unset, the latest
+  version will be installed.
 * ``DIB_IPA_EXTRA_HARDWARE_PACKAGES`` a space-separated list of additional
   system packages to install.

--- a/elements/ipa-extra-hardware/install.d/61-ipa-extra-hardware
+++ b/elements/ipa-extra-hardware/install.d/61-ipa-extra-hardware
@@ -7,7 +7,7 @@ set -eu
 set -o pipefail
 
 IPADIR=/usr/share/ironic-python-agent
-PACKAGE=hardware${DIB_IPA_HARDWARE_VERSION:+==}${DIB_IPA_HARDWARE_VERSION:-}
+PACKAGE=${DIB_IPA_HARDWARE_PACKAGE:-hardware${DIB_IPA_HARDWARE_VERSION:+==}${DIB_IPA_HARDWARE_VERSION:-}}
 
 # Install the python hardware package inside the virtual environment.
 $IPADIR/venv/bin/pip install -c $IPADIR/upper-constraints.txt $PACKAGE

--- a/elements/ipa-extra-hardware/package-installs.yaml
+++ b/elements/ipa-extra-hardware/package-installs.yaml
@@ -2,8 +2,7 @@ biosdevname:
 ethtool:
 fio:
 hdparm:
-# FIXME: this causes a traceback when enabled with hardware-0.18.
-#infiniband-diags:
+infiniband-diags:
 ipmitool:
 lldpad:
 lshw:


### PR DESCRIPTION
These changes are required, along with https://github.com/redhat-cip/hardware/pull/42, to fix failures seen during hardware inspection.