### PR TITLE
Add adhoc-elements elements

### DIFF
--- a/elements/adhoc-elements/README.rst
+++ b/elements/adhoc-elements/README.rst
@@ -1,0 +1,8 @@
+==============
+adhoc elements
+==============
+Define adhoc elements via environmental variables
+
+* ``DIB_ADHOC_<REF>_SCRIPT``: SCRIPT to place in TMP_HOOKS (mutually exclusive with ``DIB_ADHOC_<REF>_DATA``)
+* ``DIB_ADHOC_<REF>_DATA``: DATA to place in TMP_HOOKS (mutually exclusive with ``DIB_ADHOC_<REF>_SCRIPT``)
+* ``DIB_ADHOC_<REF>_PATH``: path under $TMP_HOOKS to place the BLOB

--- a/elements/adhoc-elements/extra-data.d/10-prepare-adhoc-elements
+++ b/elements/adhoc-elements/extra-data.d/10-prepare-adhoc-elements
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# define either DIB_ADHOC_EXAMPLE_SCRIPT or DIB_ADHOC_EXAMPLE_DATA not both
+# DIB_ADHOC_EXAMPLE_SCRIPT: script content
+# DIB_ADHOC_EXAMPLE_DATA: data (not executed)
+# DIB_ADHOC_EXAMPLE_PATH: path under $TMP_HOOKS where the hook is installed
+
+for value in $(compgen -v); do
+    if [[ "$value" =~ DIB_ADHOC_(.*)_SCRIPT ]] || [[ "$value" =~ DIB_ADHOC_(.*)_DATA ]]; then
+        name="${BASH_REMATCH[1]}"
+        script_ref="DIB_ADHOC_""$name""_SCRIPT"
+        script="${!script_ref:-}"
+        data_ref="DIB_ADHOC_""$name""_DATA"
+        data="${!data_ref:-}"
+        path_ref="DIB_ADHOC_""$name""_PATH"
+        path="${!path_ref}"
+        if [ -n "$data" ] && [ -n "$script" ]; then
+            die "you should only define $data_ref or $script_ref, not both."
+        fi
+        if [ -z "$path" ]; then
+            die "you must set $path_ref"
+        fi
+        dir="$(dirname ${TMP_HOOKS_PATH}/${path})"
+        test -d "$dir" || mkdir -p "$dir"
+        if [ -n "$script" ]; then
+            echo "$script" > "$TMP_HOOKS_PATH/$path"
+            chmod +x "$TMP_HOOKS_PATH/$path"
+        else
+            echo "$data" > "$TMP_HOOKS_PATH/$path"
+        fi
+    fi
+done


### PR DESCRIPTION
This element allows you to define adhoc-elements where creating a full on element seems overkill. This is useful for very short scripts. The use case is to enable the centos vault.