### PR TITLE
Add growpart-gpt DIB element

### DIFF
--- a/elements/growpart-gpt/README.md
+++ b/elements/growpart-gpt/README.md
@@ -1,0 +1,6 @@
+growpart-gpt element
+====================
+
+This directory contains a
+`[diskimage-builder](https://github.com/openstack/diskimage-builder)` element
+to install required dependencies for growing GPT partitions.

--- a/elements/growpart-gpt/elements-deps
+++ b/elements/growpart-gpt/elements-deps
@@ -1,0 +1,1 @@
+package-installs

--- a/elements/growpart-gpt/package-installs.yaml
+++ b/elements/growpart-gpt/package-installs.yaml
@@ -1,0 +1,2 @@
+cloud-utils-growpart:
+gdisk:


### PR DESCRIPTION
This element allows growpart to resize GPT-partitioned disks successfully by installing gdisk.